### PR TITLE
Update FW 4.89 Latest Version

### DIFF
--- a/rpcs3/rpcs3qt/main_window.cpp
+++ b/rpcs3/rpcs3qt/main_window.cpp
@@ -1139,7 +1139,7 @@ void main_window::HandlePupInstallation(const QString& file_path, const QString&
 		return;
 	}
 
-	static constexpr std::string_view cur_version = "4.88";
+	static constexpr std::string_view cur_version = "4.89";
 
 	std::string version_string;
 


### PR DESCRIPTION
Updates the latest FW version according to: https://www.playstation.com/en-us/support/hardware/ps3/system-software/
List of changes:
Version 4.89
Signing in to PlayStation Network now requires a device password for enhanced account protection.
Account creation for PlayStation Network and some account management features are no longer available on the console. Use your PC or mobile browser to use account management features with improved performance, speed, and safety.